### PR TITLE
chore(license): update source code headers + copyright year

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2023 Target Brands, Inc.
+Copyright 2022 Target Brands, Inc.
 ```
 
-[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License, Version 2.0](../LICENSE)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,9 +35,7 @@ linters-settings:
   # https://github.com/denis-tingaikin/go-header
   goheader:
     template: |-
-      Copyright (c) {{ YEAR }} Target Brands, Inc. All rights reserved.
-      
-      Use of this source code is governed by the LICENSE file in this repository.
+      SPDX-License-Identifier: Apache-2.0
 
   # https://github.com/client9/misspell
   misspell:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-#
-# Use of this source code is governed by the LICENSE file in this repository.
+# SPDX-License-Identifier: Apache-2.0
 
 #########################################################
 ##    docker build --no-cache -t vela-ansible:local .    ##

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright (c) 2023 Target Brands, Inc.
+Copyright 2022 Target Brands, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-# Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-#
-# Use of this source code is governed by the LICENSE file in this repository.
+# SPDX-License-Identifier: Apache-2.0
 
 # capture the current date we build the application from
 BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)

--- a/action/lint/command.go
+++ b/action/lint/command.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // command - runs ansible-lint cli
 

--- a/action/lint/command_test.go
+++ b/action/lint/command_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package lint
 

--- a/action/lint/config.go
+++ b/action/lint/config.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // config - ansible-lint configuration
 

--- a/action/lint/executor.go
+++ b/action/lint/executor.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // executor - executes ansible-lint
 

--- a/action/lint/executor_test.go
+++ b/action/lint/executor_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package lint
 

--- a/action/lint/flag.go
+++ b/action/lint/flag.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // flag - sets flags for ansible-lint and creates ansible-lint cli
 

--- a/action/lint/flag_test.go
+++ b/action/lint/flag_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package lint
 

--- a/action/lint/lint.go
+++ b/action/lint/lint.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // lint - ansible-lint flags, struct, and binary
 

--- a/action/lint/validate.go
+++ b/action/lint/validate.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // validate - validates ansible-lint to make sure that a playbook is defined.
 

--- a/action/lint/validate_test.go
+++ b/action/lint/validate_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package lint
 

--- a/action/playbook/command.go
+++ b/action/playbook/command.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // command - runs ansible-playbook cli
 

--- a/action/playbook/command_test.go
+++ b/action/playbook/command_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package playbook
 

--- a/action/playbook/config.go
+++ b/action/playbook/config.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // config - ansible-playbook configuration
 

--- a/action/playbook/executor.go
+++ b/action/playbook/executor.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // executor - executes ansible-playbook
 

--- a/action/playbook/executor_test.go
+++ b/action/playbook/executor_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package playbook
 

--- a/action/playbook/flag.go
+++ b/action/playbook/flag.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // flag - sets flags for ansible-playbook and creates ansible-playbook cli
 

--- a/action/playbook/flag_test.go
+++ b/action/playbook/flag_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package playbook
 

--- a/action/playbook/playbook.go
+++ b/action/playbook/playbook.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // playbook - ansible-playbook flags, struct, and binary
 

--- a/action/playbook/validate.go
+++ b/action/playbook/validate.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // validate - validates ansible-playbook to make sure that a playbook and inventory is defined.
 

--- a/action/playbook/validate_test.go
+++ b/action/playbook/validate_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package playbook
 

--- a/cmd/vela-ansible/main.go
+++ b/cmd/vela-ansible/main.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
@@ -35,7 +33,7 @@ func main() {
 		Name:      "vela-ansible",
 		HelpName:  "vela-ansible",
 		Usage:     "Vela Ansible Plugin for running ansible-playbook and ansible-lint.",
-		Copyright: "Copyright (c) 2023 Target Brands, Inc. All rights reserved.",
+		Copyright: "Copyright 2022 Target Brands, Inc. All rights reserved.",
 		Authors: []*cli.Author{
 			{
 				Name:  "Vela Admins",

--- a/cmd/vela-ansible/plugin.go
+++ b/cmd/vela-ansible/plugin.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 // plugin - action controller of the plugin.
 

--- a/cmd/vela-ansible/plugin_test.go
+++ b/cmd/vela-ansible/plugin_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package version
 


### PR DESCRIPTION
ref: https://github.com/go-vela/community/issues/747

- replaces code file license headers with SPDX header (see https://spdx.dev/ids/#why); this removes copyright + year
- update golangci-lint rule to ensure code file enforcement
- use first commit date for copyright year and updates year in other select places
- format is changed to match "Copyright [yyyy] [name of copyright owner]" as shown here: https://www.apache.org/licenses/LICENSE-2.0.html
