### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,12 @@ RUN apk --update add --virtual \
 
 RUN pip3 install --upgrade \
         pip \
-        cffi
+        cffi --break-system-packages
 
 RUN pip3 install \
         wheel \
         ansible==${ANSIBLE_VERSION} \
-        ansible-lint
+        ansible-lint --break-system-packages
 
 RUN apk del \
         .build-deps


### PR DESCRIPTION
Adding `--break-system-packages` to pip3 commands
Current deps update broke Dockerfile with following error:
`error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide python installation should be maintained using the system
    package manager (apk) only.
    
    If the package in question is not packaged already (and hence installable via
    "apk add py3-somepackage"), please consider installing it inside a virtual
    environment, e.g.:
    
    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by re-sourcing
    the activate file.
    
    To automatically manage virtual environments, consider using pipx (from the
    pipx package).

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.`